### PR TITLE
Deal with import _strptime python bug, update travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,19 +2,36 @@ language: python
 env:
   global:
     - secure: "abidki0eF4cOKOHkXR4jdWyp1tWglmxYmWCFgKE9gK6cQDcA7V2Z4ZeuuWjir9ZpmYp0lVk/3iF2/0d5SPFy2+hlph7tK3rC+5UvjG1WxeJQh7ybNBWUHOQx5vmfG0H9ZS/OCjGnjMDo9UlxpPJCdxM5vl3uBhBh2KJXkqtCLg7b0lFMq/4HT17UswRlw7L9H8W/gcTGCOqxrvWpg5iz/sKfNpfaGJzbCtGp1S2JieZMTymBWwsLAy7bvDV+DTmPE1Lqax7REngkBtzVte0xAPO+XA6wYTnwnR0yDrKddEeIa5kN860oxlGY7ppuYjaKKvl+evGvKHFGVmSmLBtWzcH2vaIJHZhaAn4hfd5ifGdekohayr9YJq47zNbEGUT+mmzthpC6x2X3/EIqsjCiP7TTdC/36+qrROv1O0QpBlzrnmc0Y7wRayPtYEfBfgNpCW2MxbPi78y6TuJqF13UslGtxBSYEcDB5rgwUUl0AH5MgJo6epjqzYfHna0/NotB96TQv0MsOoIiBupApg5RteJduNZ6SirzyDAim2zFjJll6JJE2ghL3a0e5d1amel1q/UI8bVLsy503JhQU/q8E5kiTATRN/T8qVkuQvr/R4jwp1ds8bEDSayBgq4ACvu/xw7MQfkbZMUQBnUaDje3auXhF3bbFlRIfBTveUJlv1Q="
-
 install:
   - pip install GitPython
   - export TRAVIS_COMMIT_MSG="$TRAVIS_REPO_SLUG - $(git log --format=%B --no-merges -n 1)"
-  - git clone https://github.com/xbmc-catchuptv-au/repo-devel.git .deploy
 script:
-  - cd .deploy
-  - ./manage_repo.py ../
-after_script:
+  - test "$TRAVIS_PULL_REQUEST" = "false" || travis_terminate 0
+  - test "$TRAVIS_BRANCH" = "master" || travis_terminate 0
+  - >
+    git clone https://github.com/xbmc-catchuptv-au/repo-devel.git $TRAVIS_BUILD_DIR/.deploy && 
+    cd $TRAVIS_BUILD_DIR/.deploy && 
+    ./manage_repo.py $TRAVIS_BUILD_DIR
+  - |
+    if [ -n "$TRAVIS_TAG" ]; then
+        git clone https://github.com/xbmc-catchuptv-au/repo.git $TRAVIS_BUILD_DIR/.deploy-prod && \
+        cd $TRAVIS_BUILD_DIR/.deploy-prod && \
+        ./manage_repo.py $TRAVIS_BUILD_DIR || travis_terminate 1
+    fi
   - git config --global user.email 'aussieaddons@aussieaddons.com'
   - git config --global user.name 'Aussie Add-ons Bot'
+  - cd $TRAVIS_BUILD_DIR/.deploy
   - git config credential.helper "store --file=.git/credentials"
   - echo "https://${GH_TOKEN}:@github.com" > .git/credentials
   - git add .
   - git commit --allow-empty -m "$TRAVIS_COMMIT_MSG"
   - git push
+  - |
+    if [ -n "$TRAVIS_TAG" ]; then
+        cd $TRAVIS_BUILD_DIR/.deploy-prod
+        git config credential.helper "store --file=.git/credentials"
+        echo "https://${GH_TOKEN}:@github.com" > .git/credentials
+        git add . && \
+        git commit --allow-empty -m "Update $(basename `git -C $TRAVIS_BUILD_DIR rev-parse --show-toplevel`) to $TRAVIS_TAG" && \
+        git push || travis_terminate 1
+    fi

--- a/lib/aussieaddonscommon/utils.py
+++ b/lib/aussieaddonscommon/utils.py
@@ -9,6 +9,10 @@ import xbmc
 import xbmcaddon
 import xbmcgui
 
+# This import is to deal with a python bug with strptime:
+#   ImportError: Failed to import _strptime because the import lockis
+#   held by another thread.
+import _strptime # noqa: F401
 
 ADDON = xbmcaddon.Addon()
 


### PR DESCRIPTION
Travis-ci builds will now exit if triggered from a PR or any commits coming from a branch that isn't master.

I put the import _strptime in the utils as it seems pretty much all of the add-ons are affected.