### PR TITLE
Ensure debug mode is enabled for user reports.

### DIFF
--- a/lib/aussieaddonscommon/issue_reporter.py
+++ b/lib/aussieaddonscommon/issue_reporter.py
@@ -157,7 +157,9 @@ def is_reportable(exc_type, exc_value, exc_traceback):
     """
 
     # AttributeError: global name 'foo' is not defined
-    error = '%s: %s' % (exc_type.__name__, ', '.join(exc_value.args))
+    error = '%s: %s' % (
+        exc_type.__name__, ', '.join(
+            utils.ensure_ascii(x) for x in exc_value.args))
 
     # Don't show any dialogs when user cancels
     if exc_type.__name__ == 'SystemExit':


### PR DESCRIPTION
This should hopefully stop the stream of unhelpful reports.

There is now a dialog yes/no to confirm creating the issue/uploading log. Plently of issues have undoubtedly come from curious users checking any setting they can.

Some issues have also been failing to submit due to the unicode error that caused the issue also causing the issue reporter to fail. It seems to always be from unicode contained in large JSON or XML files which is included in the exception args. When the issue formatter tries to split the exception data on newlines there is then a list hundreds of items long that is passed to the xbmcgui Dialog object which only takes a max of 3, causing failure. We now omit the data which caused the exception which is ok because ther is enough information in the log to get to the source which caused it including the position of the offending unicode character.