### PR TITLE
No issue reporting for unsupported add-ons, busy dialog box fix

### DIFF
--- a/lib/aussieaddonscommon/issue_reporter.py
+++ b/lib/aussieaddonscommon/issue_reporter.py
@@ -214,7 +214,8 @@ def blacklisted_hostname(connection_info):
                      'softlayer',
                      'micfo',
                      'total server solutions',  # PIA
-                     'host universal pty ltd']  # NordVPN
+                     'host universal pty ltd',  # NordVPN
+                     'AS45671']  # serversaustralia.com.au
 
     hostname_blacklist = ['ipvanish',
                           'zoogvpn',

--- a/lib/aussieaddonscommon/utils.py
+++ b/lib/aussieaddonscommon/utils.py
@@ -262,6 +262,14 @@ def is_debug():
         return True
 
 
+def is_supported():
+    unsupported_addons = ['plugin.video.catchuptv.au.ten',
+                          'plugin.video.plus7']
+    if get_addon_id() in unsupported_addons:
+        return False
+    return True
+
+
 def user_report():
     if is_debug():
         send_report('User initiated report', user_initiated=True)
@@ -273,6 +281,8 @@ def user_report():
 
 def send_report(title, trace=None, connection_info=None, user_initiated=False):
     try:
+        dialog_progress = xbmcgui.DialogProgress()
+        dialog_created = False
         import issue_reporter
         log("Reporting issue to GitHub")
 
@@ -286,9 +296,19 @@ def send_report(title, trace=None, connection_info=None, user_initiated=False):
                 get_addon_name(), get_addon_version()),
                     'Please confirm you would like to submit an issue report '
                     'and upload your logfile to Github. '):
+                log('Cancelled user report')
                 return
+
+        if not is_supported():
+            xbmcgui.Dialog().ok('{0} v{1}'.format(
+                get_addon_name(), get_addon_version()),
+                'This add-on is no longer supported by Aussie Add-ons.')
+            log('Add-on not supported, aborting issue report.')
+            return
+
         # Show dialog spinner, and close afterwards
-        xbmc.executebuiltin("ActivateWindow(busydialog)")
+        dialog_progress.create('Uploading issue to GitHub...')
+        dialog_created = True
         report_url = issue_reporter.report_issue(title, trace, connection_info)
 
         split_url = report_url.replace('/issue-reports', ' /issue-reports')
@@ -301,7 +321,8 @@ def send_report(title, trace=None, connection_info=None, user_initiated=False):
         traceback.print_exc()
         log('Failed to send report')
     finally:
-        xbmc.executebuiltin("Dialog.Close(busydialog)")
+        if dialog_created:
+            dialog_progress.close()
 
 
 def handle_error(message):


### PR DESCRIPTION
Disallow reporting for removed ten and plus7 add-ons.

The old method of showing a busy dialog box seems to not work anymore. Reports sometimes get double or triple reported as you can start a new one while the old is running in the background. Now uses the progress dialog box - there is a 'busy' dialog box type but that was only introduced in Krypton.